### PR TITLE
Expose deviceName, TappyStatus

### DIFF
--- a/TappyBle/TappyBleDevice.swift
+++ b/TappyBle/TappyBleDevice.swift
@@ -25,7 +25,7 @@ import Foundation
 
 @objc
 public class TappyBleDevice : NSObject {
-    var deviceName : String
+    @objc public var deviceName : String
     @objc public var deviceId : UUID = UUID()
     
     @objc init(name : String, deviceId : UUID){

--- a/TappyBle/TappyBleScanner.swift
+++ b/TappyBle/TappyBleScanner.swift
@@ -71,6 +71,10 @@ public class TappyBleScanner : NSObject, CBCentralManagerDelegate{
         changeStateAndNotify(newState: state)
     }
     
+    @objc public func getState() -> TappyBleScannerStatus {
+        return state
+    }
+
     private func changeStateAndNotify(newState: TappyBleScannerStatus){
         state = newState
        statusListener(newState)

--- a/TappyReader/SerialTappy.swift
+++ b/TappyReader/SerialTappy.swift
@@ -82,7 +82,7 @@ public class SerialTappy : NSObject, Tappy {
         responseListener = {_ in func emptyResponseListener(message: TCMPMessage) -> (){}}
     }
     
-    public func setStatusListener(listner: @escaping (TappyStatus) -> ()) {
+    @objc public func setStatusListener(listner: @escaping (TappyStatus) -> ()) {
         statusListener = listner
     }
     

--- a/TappyReader/TappyStatus.swift
+++ b/TappyReader/TappyStatus.swift
@@ -22,7 +22,7 @@
  */
 
 import Foundation
-
+@objc
 public enum TappyStatus : Int {
     case STATUS_DISCONNECTED = 1
     case STATUS_CONNECTING = 2

--- a/TappyReaderTests/SerialTappyTest.swift
+++ b/TappyReaderTests/SerialTappyTest.swift
@@ -60,19 +60,19 @@ class TestCommunicator : NSObject, TappySerialCommunicator{
         return
     }
     
-    func connect() {
+    @objc func connect() {
         return
     }
     
-    func disconnect() {
+    @objc func disconnect() {
         return
     }
     
-    func close() {
+    @objc func close() {
         return
     }
     
-    func initialize() {
+    @objc func initialize() {
         return
     }
     @objc

--- a/TappyReaderTests/SerialTappyTest.swift
+++ b/TappyReaderTests/SerialTappyTest.swift
@@ -60,19 +60,19 @@ class TestCommunicator : NSObject, TappySerialCommunicator{
         return
     }
     
-    @objc func connect() {
+    func connect() {
         return
     }
     
-    @objc func disconnect() {
+    func disconnect() {
         return
     }
     
-    @objc func close() {
+    func close() {
         return
     }
     
-    @objc func initialize() {
+    func initialize() {
         return
     }
     @objc


### PR DESCRIPTION
Hey David,

This will expose the SerialTappy.setStatusListener function so I can monitor when the tappy is connected.